### PR TITLE
Updated to use D8 instead of deprecated R8

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
-android.enableR8=true
+android.enableD8=true
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
https://stackoverflow.com/questions/60558454/build-gradle-the-option-android-enabler8-is-deprecated-and-should-not-be-used